### PR TITLE
docs: document Command System V2 and Atelier REPL

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -23,7 +23,7 @@ commit-date-format: 'yyyy-MM-dd'
 # Ignore merge commits (except those that should trigger releases)
 merge-message-formats: '^Merge (branch|tag|pull request)'
 
-next-version: 'v0.2.1'
+next-version: 'v0.3.1'
 
 # Branch-specific configuration
 branches:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ These are reachable directions, even though the launcher does not currently ship
 | 🛡 **Bundled TShock port** | Ships with a USP-adapted TShock baseline ready for use |
 | 💻 **Per-context console isolation** | Independent, auto-reconnecting console I/O windows for each world context, plus semantic readline prompts and live status bars |
 | 🚀 **RID-targeted publishing** | Publisher produces reproducible, runtime-specific directory trees |
+| ⚡ **Command System V2** | A brand-new declarative command framework — 200+ TShock commands already migrated, with smart context-aware completion built in. Plugins define commands as structured declarations; the framework handles binding, permissions, output, and audit logging across terminal, player, and REST endpoints |
+| 🧪 **Atelier REPL** | A Roslyn-powered C# workspace running inside the live runtime. Write and run code against real server state, get IDE-quality completion and diagnostics, and iterate without restarting — a proper workbench for operators and developers alike |
 
 ---
 
@@ -555,6 +557,8 @@ graph LR
 | **Config registration** | Configs stored in `config/<PluginName>/`, supports auto-reload (`TriggerReloadOnExternalChange(true)`) |
 | **Collectible contexts** | `ModuleLoadContext` enables unloadable plugin domains |
 
+Command System V2 is the recommended way to expose commands from plugins. Controllers are declared with attributes, and the framework handles discovery, endpoint binding, parameter parsing, and permission checks automatically. The same declaration also drives completion candidates, help text generation, and audit logging — so there is no separate usage string to maintain.
+
 → Full guide: [Plugin Development Guide](./docs/dev-plugin.md)
 
 ---
@@ -595,6 +599,8 @@ This table reflects the currently maintained/documented packaging targets, not e
 | `linux-arm64` | ❌ Not supported yet |
 | `linux-arm` | ⚠️ Partial support / needs manual verification |
 | `osx-x64` | ✅ Supported |
+
+If you want to inspect or script against a running world without writing a full plugin, Atelier REPL gives you a Roslyn workspace attached to the live runtime. You can run persistent C# sessions, query server state, call plugin APIs, and run background tasks — all without restarting. See [docs/dev-overview.md](./docs/dev-overview.md#28-atelier-repl) for session setup and meta-command reference.
 
 ---
 

--- a/docs/README.zh-cn.md
+++ b/docs/README.zh-cn.md
@@ -77,6 +77,8 @@ UnifierTSL 把 [OTAPI Unified Server Process](https://github.com/CedaryCat/OTAPI
 | 🛡 **内置 TShock 移植基线** | 内置适配 USP 的 TShock 基线，开箱可用 |
 | 💻 **上下文级控制台隔离** | 默认为每个世界实例提供独立、自动重连的控制台窗口 IO，以及语义化 readline 提示与实时状态栏 |
 | 🚀 **按 RID 发布** | Publisher 生成可复现、面向目标运行时的目录结构 |
+| ⚡ **命令系统 V2** | 全新声明式命令体系——200+ 条 TShock 命令已完成迁移，并内置智能上下文感知补全。插件通过属性标注声明命令结构，框架统一处理绑定、权限、输出和审计日志，覆盖终端、玩家和 REST 三类入口 |
+| 🧪 **Atelier REPL** | 直接运行在运行时内部的 Roslyn C# 工作台。针对真实服务器状态编写并执行代码，享有媲美 IDE 的补全与诊断体验，无需重启即可迭代——运维和开发都能用得上的正经工具 |
 
 ---
 
@@ -556,6 +558,8 @@ graph LR
 | **配置注册** | 配置存放在 `config/<PluginName>/`，支持自动重载（`TriggerReloadOnExternalChange(true)`） |
 | **可回收上下文** | `ModuleLoadContext` 支持可卸载的插件域 |
 
+命令系统 V2 是插件暴露命令的推荐方式。控制器通过属性标注声明，框架负责发现、端点绑定、参数解析和权限检查，同一份声明还会自动派生出补全候选、帮助文本和审计日志，不需要单独维护 usage 字符串。完整的 API 参考和代码示例可以在插件开发指南里找到。
+
 → 完整指南：[插件开发指南](./dev-plugin.zh-cn.md)
 
 ---
@@ -596,6 +600,8 @@ dotnet run --project src/UnifierTSL.Publisher/UnifierTSL.Publisher.csproj -- \
 | `linux-arm64` | ❌ 暂不支持 |
 | `linux-arm` | ⚠️ 部分支持 / 仍需人工验证 |
 | `osx-x64` | ✅ 支持 |
+
+如果你想在不写完整插件的情况下探索或操作运行中的世界，Atelier REPL 提供了一个直接附着在运行时上的 Roslyn 工作台。你可以在持久会话里逐步构建脚本、查询服务器状态、调用插件 API，也可以把长时间运行的操作放到后台执行——整个过程不需要重启。会话配置和元命令参考可以在 [dev-overview.zh-cn.md](./dev-overview.zh-cn.md#28-atelier-repl) 里找到。
 
 ---
 

--- a/docs/dev-overview.md
+++ b/docs/dev-overview.md
@@ -15,6 +15,8 @@ Welcome! This doc walks you through how the UnifierTSL runtime is put together o
   - [2.4 Networking & Coordinator](#24-networking--coordinator)
   - [2.5 Logging Infrastructure](#25-logging-infrastructure)
   - [2.6 Configuration Service](#26-configuration-service)
+  - [2.7 Command System V2](#27-command-system-v2)
+  - [2.8 Atelier REPL](#28-atelier-repl)
 - [3. USP Integration Points](#3-usp-integration-points)
 - [4. Public API Surface](#4-public-api-surface)
   - [4.1 Facade (`UnifierApi`)](#41-facade-unifierapi)
@@ -55,6 +57,8 @@ Welcome! This doc walks you through how the UnifierTSL runtime is put together o
 - `ModuleAssemblyLoader` – takes care of module staging, dependency extraction, collectible load contexts, and unload order.
 - `EventHub` – the central event registry that bridges MonoMod detours into priority-sorted event pipelines.
 - `Logging` subsystem – lightweight, allocation-friendly logging with metadata injection and pluggable writers.
+- `CommandSystem` – the declarative command framework: catalog, endpoint compiler, dispatcher, Prompt projection, and audit integration.
+- `AtelierPlugin` + `ReplSession` – the Roslyn-based interactive REPL, providing persistent sessions, real-time diagnostics, code completion, and a Surface-based windowed UI.
 
 ## 2. Core Services & Subsystems
 
@@ -1495,7 +1499,171 @@ For more logging examples, see `src/Plugins/TShockAPI/TShock.cs` and `src/Unifie
 - Startup precedence for launcher settings is `config/config.json` -> CLI overrides -> interactive fallback for missing port/password, and the effective startup snapshot is persisted back to `config/config.json`. After startup, edits to `config/config.json` apply to the launcher settings that support reload.
 - Root-config hot reload applies `launcher.serverPassword`, `launcher.joinServer`, additive `launcher.autoStartServers`, `launcher.listenPort` (via listener rebind), `launcher.colorfulConsoleStatus`, and `launcher.consoleStatus`.
 
-## 3. USP Integration Points
+<a id="27-command-system-v2"></a>
+### 2.7 Command System V2
+
+The command system v2 replaces the traditional string-callback model with a declarative, attribute-driven framework. Controllers are `static` classes; actions are static methods. The framework discovers these at install time, compiles them into endpoint-specific catalogs, and handles dispatch, parameter binding, permission checks, and output formatting — all from the same set of declarations.
+
+<details>
+<summary><strong>Expand Command System V2 implementation deep dive</strong></summary>
+
+#### Architecture Overview
+
+The system has five distinct layers, each handling a specific concern:
+
+**Discovery layer** (`src/UnifierTSL/Commanding`): `CommandSystemDiscovery` reflects over controller types to build a `CommandCatalog` — an immutable snapshot of all registered commands, their action paths, parameter signatures, and metadata. Reflection only happens at install time; runtime dispatch never touches it again.
+
+**Compilation layer** (`src/UnifierTSL/Commanding/Endpoints`): `CommandEndpointCatalogCompiler` takes the generic catalog and produces endpoint-specific bindings. Each endpoint type (terminal, TShock player, REST) has its own context requirements. Actions that don't satisfy an endpoint's constraints are excluded from that endpoint's catalog at compile time, not at dispatch time.
+
+**Dispatch layer** (`src/UnifierTSL/Commanding/Execution`): `CommandDispatchCoordinator` receives raw input, tokenizes it via `CommandLineLexer`, routes to the matching root and action, runs guard checks, binds parameters, invokes the action, and hands the `CommandOutcome` to the appropriate outcome writer.
+
+**Prompt layer** (`src/UnifierTSL/Commanding/Prompting`): `CommandPrompting` projects endpoint bindings into `PromptAlternativeSpec` objects. The same command definition that drives execution also drives completion candidates, semantic highlighting, and parameter hints.
+
+**TShock layer** (`src/Plugins/TShockAPI/Commanding`): Adds TShock-specific endpoint types, permission model, domain binders (player, group, region, warp, etc.), and audit log integration. The core layer stays generic; TShock semantics live entirely in the plugin. Importantly, this is an integration and extension of Command System V2 rather than a separate parallel stack, so TShock-oriented plugins can usually build directly on that existing surface instead of inventing their own command bridge.
+
+In practice, the UTSL-TS command architecture is split by ownership:
+
+- **UTSL core owns the neutral command engine**: discovery, catalog building, endpoint compilation, dispatch, generic binding rules, and prompt projection.
+- **TShock owns the game/admin-facing adaptation**: player/REST-facing endpoints, TShock permission semantics, domain binders, and TShock-specific outcome/audit behavior.
+- **Plugins choose the highest-level surface that already matches their needs**: if you are building a TShock-style admin/gameplay command, you usually attach at the TShock layer instead of re-expressing those same semantics from scratch over raw V2 primitives.
+
+#### Data Flow
+
+```
+CommandSystem.Install(configure)
+    ↓
+CommandSystemDiscovery → CommandCatalog (immutable snapshot)
+    ↓
+CommandEndpointCatalogCompiler → per-endpoint root/action bindings
+    ↓
+CommandPrompting → PromptAlternativeSpec (completion / highlighting)
+
+[User input arrives]
+    ↓
+CommandDispatchCoordinator
+    ↓
+CommandLineLexer: tokenize → prefix, root, args
+    ↓
+CommandEndpointDispatcher: path match → guard checks → parameter binding
+    ↓
+Action invoked → CommandOutcome
+    ↓
+OutcomeWriter: receipt + attachment + log → terminal / player / REST
+```
+
+#### Immutable Catalog and Atomic Swap
+
+`CommandSystem` maintains a registration dictionary. Each install or uninstall rebuilds `CommandSystemState` under the registration lock, then replaces the current snapshot. External readers consume that snapshot through `Volatile.Read`, so they always see a consistent state. Registration IDs keep ordering stable across rebuilds, which matters for help text and completion candidate stability.
+
+`ValidateConflicts` runs during install to catch duplicate root names and aliases before any user can hit the ambiguity at runtime.
+
+#### Static Controllers and the No-State Rule
+
+`CommandSystemDiscovery` requires controllers to be `static` classes with static methods. This is a deliberate constraint: controllers are declaration containers, not service instances. Runtime state flows in through injected parameters (`CommandInvocationContext`, `CancellationToken`, and `[FromAmbientContext]` values such as `ServerContext` or `TSExecutionContext`). This makes the catalog easy to snapshot, rebuild, and unload, and it prevents plugins from smuggling mutable instance state into the command lifecycle.
+
+#### Endpoint Binding Validation
+
+The endpoint compiler validates parameter constraints at compile time. If an action requires a server-scoped ambient value such as `[FromAmbientContext] ServerContext`, but the endpoint can't provide one, the compile fails at install time rather than at dispatch time. This catches mismatches before any user can trigger them.
+
+#### Mismatch Handlers
+
+Each controller can have at most one `[MismatchHandler]`. It fires when the root matches but the action path or parameters don't. Mismatch handlers can only consume injected values — they can't declare user-bound parameters. This prevents error handling from becoming a second command parser.
+
+#### Parameter Binding Sources
+
+| Source | Description |
+|--------|-------------|
+| User tokens | Positional arguments from the command line |
+| Remaining text / args | Everything after the last bound token, as string or `string[]` |
+| Flags | Named options extracted from any position in the token list |
+| Invocation context | `CommandInvocationContext` |
+| Cancellation token | For long-running or background operations |
+| Ambient context | `[FromAmbientContext]` values such as `ServerContext`, `TSExecutionContext`, and background activity feedback objects |
+
+Scalar types (`string`, `bool`, `int`, numeric types, `enum`) bind directly from tokens. Complex types use `CommandBindingAttribute` subclasses. TShock adds domain-specific binders for `TSPlayer`, `Group`, `Region`, `Warp`, `UserAccount`, and more. `CommandInvocationContext` and `CancellationToken` are recognized implicitly; other runtime values come from the ambient execution context when explicitly marked.
+
+</details>
+
+#### Best Practices
+
+1. **Keep controllers stateless** — inject context through parameters, not fields
+2. **Declare permissions on TShock actions** — the dispatcher enforces them before binding
+3. **Prefer the TShock integration when that's your target surface** — plugins like `CommandTeleport` can use the TShock-facing V2 facilities directly instead of building a second command-access layer
+4. **Use implicit bindings for common domain types** — register them once in the binding registry
+5. **Add a mismatch handler** — it's the user-facing error surface for your command tree
+6. **Let the catalog drive help text** — don't maintain separate usage strings
+7. **Validate at install time** — declare context requirements so the compiler catches mismatches early
+
+<a id="28-atelier-repl"></a>
+### 2.8 Atelier REPL
+
+Atelier is a Roslyn-based interactive C# workspace embedded in the Unifier runtime. It goes well beyond "run a script" — it provides persistent sessions with incremental compilation, real-time diagnostics, code completion, signature help, semantic highlighting, virtual bracket pairing, console output redirection, background task tracking, and a Surface-based windowed UI.
+
+<details>
+<summary><strong>Expand Atelier REPL implementation deep dive</strong></summary>
+
+#### Session Model
+
+`ReplSession` (`src/Plugins/Atelier/Session`) maintains a Roslyn `ScriptState` that grows incrementally with each submission. Two execution modes are available:
+
+- **Persistent submit**: compiles on top of the current state and updates session state. Variables, imports, and definitions persist across submissions.
+- **Transient run**: executes against the current state but discards the result. Useful for one-off queries or validation without polluting session state.
+
+Sessions can target the launcher context or a specific running server. The target determines which globals are in scope — every session gets `Launcher`, `Log`, `HostLabel`, `TargetLabel`, `Cancellation`, `PendingTasks`, and `LastTask`, while server-targeted sessions additionally expose `Server`, a wrapper around the target `ServerContext` with dispatcher, peer, and snapshot helpers.
+
+#### Roslyn Workspace Integration
+
+The REPL maintains a Roslyn workspace alongside the execution state (`src/Plugins/Atelier/Session/Roslyn`). The workspace tracks the current document and provides language services:
+
+- **Diagnostics**: real-time error/warning markers as you type, before you submit
+- **Completion**: context-aware candidate lists triggered by `.` or manual request
+- **Signature help**: method overload display when you open a call's parenthesis
+- **Semantic highlighting**: type-aware coloring beyond syntax
+
+A warmup pass runs after initialization to pre-load Roslyn's core assemblies, reducing first-use latency.
+
+#### Draft vs. Source
+
+The REPL maintains two text buffers:
+
+- **Draft**: what the user sees, including virtual bracket hints and other visual aids
+- **Source**: the actual source text used for compilation and execution
+
+This separation lets the UI provide rich visual feedback without corrupting the code that Roslyn actually compiles.
+
+#### Surface Window Lifecycle
+
+The REPL window uses `ISurfaceSession` and an interaction scope (`src/Plugins/Atelier/Presentation/Window`). On close, the system terminates the scope, unsubscribes events, unbinds the console, cancels pending reads, drains the command queue, cancels processing, disposes the surface session, and finally releases the `ReplSession`. This sequence ensures clean resource release with no dangling references.
+
+#### Plugin Assembly References
+
+The REPL can reference currently loaded plugin assemblies, giving scripts direct access to plugin public APIs. When a referenced assembly changes (plugin reload or unload), the session is marked invalid. Users see a prompt explaining why and can open a fresh session against the updated assemblies.
+
+#### Meta-Commands
+
+Meta-commands start with `:` and control the REPL itself rather than executing C# code:
+
+| Command | Effect |
+|---------|--------|
+| `:help` | Show available meta-commands |
+| `:reset` | Reset session state |
+| `:clear` | Clear the output area |
+| `:imports` | List baseline/effective imports and reference paths |
+| `:target` | Show the current target and invocation host |
+| `:paste [on|off]` | Toggle paste mode for multi-line submissions |
+| `:transient <code>` | Run transient code without committing it |
+
+Background work is tracked through `PendingTasks` and `LastTask`; there is no separate `:jobs` or `:cancel` meta-command in the current implementation.
+
+</details>
+
+#### Best Practices
+
+1. **Use transient mode for queries** — it doesn't pollute session state
+2. **Target the right context** — launcher context for global state, server context for world-specific operations
+3. **Watch for session invalidation** — plugin reloads will mark your session stale
+4. **Use background tasks for long operations** — the REPL stays responsive while they run
+5. **Prefer `:reset` over closing and reopening** — it's faster when you just want a clean slate
 
 - `ServerContext` inherits USP's `RootContext`, plugging Unifier services into the context (custom console, packet receiver, logging metadata). Everything that touches Terraria world/game state goes through this context.
 - The networking patcher (`UnifiedNetworkPatcher`) detours `NetplaySystemContext` functions to share buffers and coordinate send/receive paths across servers.

--- a/docs/dev-overview.zh-cn.md
+++ b/docs/dev-overview.zh-cn.md
@@ -15,6 +15,8 @@
   - [2.4 网络和协调器](#24-networking--coordinator)
   - [2.5 日志记录基础设施](#25-logging-infrastructure)
   - [2.6 配置服务](#26-configuration-service)
+  - [2.7 命令系统 V2](#27-命令系统-v2)
+  - [2.8 Atelier REPL](#28-atelier-repl)
 - [3. USP 集成点](#3-usp-integration-points)
 - [4. 公共 API 接口](#4-public-api-surface)
   - [4.1 门面 (`UnifierApi`)](#41-facade-unifierapi)
@@ -59,6 +61,8 @@
 - `ModuleAssemblyLoader` – 负责模块暂存、依赖项提取、可收集的加载上下文和卸载顺序。
 - `EventHub` – 中央事件注册表，将 MonoMod detour 接入按优先级排序的事件管道。
 - `Logging` 子系统 – 轻量级、分配友好的日志记录，具有元数据注入和可插拔写入器。
+- `CommandSystem` – 声明式命令框架：命令目录、端点编译器、分发器、Prompt 投影以及审计日志集成。
+- `AtelierPlugin` + `ReplSession` – 基于 Roslyn 的交互式 REPL，提供持久会话、实时诊断、代码补全以及基于 Surface 的窗口化交互界面。
 
 <a id="2-core-services--subsystems"></a>
 ## 2. 核心服务和子系统
@@ -1506,8 +1510,171 @@ Output in Server1's console window with server-specific colors
 - 启动器设置的启动优先级是 `config/config.json` -> CLI 覆盖 -> 缺失端口/密码时的交互式补全，并会把启动阶段生效快照回写到 `config/config.json`。启动完成后，对 `config/config.json` 的修改会应用到支持热重载的启动器设置。
 - 根配置热重载会应用 `launcher.serverPassword`、`launcher.joinServer`、追加式 `launcher.autoStartServers`、通过重绑监听器实现的 `launcher.listenPort`、`launcher.colorfulConsoleStatus`，以及 `launcher.consoleStatus`。
 
-<a id="3-usp-integration-points"></a>
-## 3. USP 集成点
+<a id="27-命令系统-v2"></a>
+### 2.7 命令系统 V2
+
+命令系统 v2 用声明式、属性驱动的框架取代了传统的字符串回调模式。控制器是 `static` 类，动作是静态方法。框架在安装时完成发现，将命令编译为各端点专属的目录，并统一处理分发、参数绑定、权限检查和输出格式化——这一切都来自同一套声明。
+
+<details>
+<summary><strong>展开命令系统 V2 实现细节深挖</strong></summary>
+
+#### 架构概述
+
+整个系统分为五个层次，各自负责不同的关切点：
+
+**发现层**（`src/UnifierTSL/Commanding`）：`CommandSystemDiscovery` 通过反射扫描控制器类型，构建 `CommandCatalog`——一份包含所有已注册命令、动作路径、参数签名和元数据的不可变快照。反射只在安装时发生一次，运行时分发不再触碰它。
+
+**编译层**（`src/UnifierTSL/Commanding/Endpoints`）：`CommandEndpointCatalogCompiler` 将通用目录编译为各端点专属的绑定。每种端点类型（终端、TShock 玩家、REST）都有自己的上下文要求。不满足端点约束的动作会在编译阶段就被排除，而不是等到分发时才处理。
+
+**分发层**（`src/UnifierTSL/Commanding/Execution`）：`CommandDispatchCoordinator` 接收原始输入，通过 `CommandLineLexer` 进行词法分析，路由到匹配的根命令和动作，执行守卫检查，绑定参数，调用动作，并将 `CommandOutcome` 交给相应的输出写入器。
+
+**Prompt 层**（`src/UnifierTSL/Commanding/Prompting`）：`CommandPrompting` 将端点绑定投影为 `PromptAlternativeSpec` 对象。驱动执行的同一份命令定义，同样驱动补全候选、语义高亮和参数提示。
+
+**TShock 层**（`src/Plugins/TShockAPI/Commanding`）：添加了 TShock 专属的端点类型、权限模型、领域绑定器（玩家、组、区域、warp 等）以及审计日志集成。核心层保持通用性，TShock 语义完全留在插件层。更重要的是，这里是对 Command System V2 的接入与扩展，而不是另一套平行命令栈；因此面向 TShock 的插件通常可以直接复用这层现成表面，而不必自己再发明一座命令桥。
+
+落到职责划分上，UTSL-TS 这一层的命令架构大致分成三段：
+
+- **UTSL core 拥有中立命令引擎**：发现、目录构建、端点编译、分发、通用绑定规则和 Prompt 投影。
+- **TShock 拥有面向游戏/管理的适配层**：玩家/REST 端点、TShock 权限语义、领域绑定器，以及 TShock 专属的结果输出与审计行为。
+- **插件作者选择最贴近需求的现成表面**：如果你做的是 TShock 风格的管理/游戏命令，通常就应当直接挂在 TShock 这一层，而不是再用原始 V2 基元把同一套语义重写一遍。
+
+#### 数据流动
+
+```
+CommandSystem.Install(configure)
+    ↓
+CommandSystemDiscovery → CommandCatalog（不可变快照）
+    ↓
+CommandEndpointCatalogCompiler → 各端点的根命令/动作绑定
+    ↓
+CommandPrompting → PromptAlternativeSpec（补全 / 高亮）
+
+[用户输入到达]
+    ↓
+CommandDispatchCoordinator
+    ↓
+CommandLineLexer：词法分析 → 前缀、根命令、参数
+    ↓
+CommandEndpointDispatcher：路径匹配 → 守卫检查 → 参数绑定
+    ↓
+动作被调用 → CommandOutcome
+    ↓
+OutcomeWriter：receipt + attachment + log → 终端 / 玩家 / REST
+```
+
+#### 不可变目录与原子替换
+
+`CommandSystem` 内部维护一个注册字典。每次安装或卸载时，都会在注册锁内重新构建 `CommandSystemState`，然后替换当前快照。外部读取者通过 `Volatile.Read` 消费该快照，因此始终能看到一致状态。注册 ID 保证了跨重建的排序稳定性，这对帮助文本和补全候选的稳定性很重要。
+
+`ValidateConflicts` 在安装阶段运行，在任何用户触发歧义之前就捕获重复的根命令名称和别名。
+
+#### 静态控制器与无状态原则
+
+`CommandSystemDiscovery` 要求控制器必须是带静态方法的 `static` 类。这是一个有意为之的约束：控制器是声明容器，而不是服务实例。运行时状态通过注入参数流入（`CommandInvocationContext`、`CancellationToken`，以及像 `ServerContext`、`TSExecutionContext` 这样的 `[FromAmbientContext]` 值）。这使得目录易于快照、重建和卸载，同时防止插件将可变实例状态塞进命令生命周期。
+
+#### 端点绑定校验
+
+端点编译器在编译阶段就验证参数约束。如果某个动作要求服务器作用域的 ambient 值，例如 `[FromAmbientContext] ServerContext`，但端点无法提供该上下文，编译会在安装时就失败，而不是等到分发时才暴露问题。
+
+#### Mismatch Handler
+
+每个控制器最多可以挂载一个 `[MismatchHandler]`。当根命令匹配但动作路径或参数不匹配时，它会被触发。Mismatch handler 只能消费注入值，不能声明用户绑定的参数——这防止了错误处理演变成第二套命令解析逻辑。
+
+#### 参数绑定来源
+
+| 来源 | 说明 |
+|------|------|
+| 用户 token | 命令行中的位置参数 |
+| 剩余文本 / 参数 | 最后一个绑定 token 之后的所有内容，可以是字符串或 `string[]` |
+| Flags | 从 token 列表任意位置提取的命名选项 |
+| 调用上下文 | `CommandInvocationContext` |
+| 取消令牌 | 用于长时间运行或后台操作 |
+| Ambient context | 通过 `[FromAmbientContext]` 获取的值，例如 `ServerContext`、`TSExecutionContext` 和后台活动反馈对象 |
+
+标量类型（`string`、`bool`、`int`、数值类型、`enum`）直接从 token 绑定，无需额外属性。复杂类型使用 `CommandBindingAttribute` 子类。TShock 为 `TSPlayer`、`Group`、`Region`、`Warp`、`UserAccount` 等添加了领域专属绑定器。`CommandInvocationContext` 和 `CancellationToken` 会被隐式识别；其他运行时值则通过显式标注从 ambient execution context 注入。
+
+</details>
+
+#### 最佳实践
+
+1. **保持控制器无状态** — 通过参数注入上下文，而不是字段
+2. **在 TShock 动作上声明权限** — 分发器会在绑定之前强制检查
+3. **如果目标表面就是 TShock，就优先复用 TShock 集成** — 像 `CommandTeleport` 这样的插件可以直接使用 TShock 面向 V2 的设施，而不是再搭第二层命令接入
+4. **对常用领域类型使用隐式绑定** — 在绑定注册表中注册一次即可
+5. **添加 mismatch handler** — 它是命令树面向用户的错误界面
+6. **让目录驱动帮助文本** — 不要单独维护 usage 字符串
+7. **在安装阶段验证** — 声明上下文要求，让编译器尽早捕获不匹配
+
+<a id="28-atelier-repl"></a>
+### 2.8 Atelier REPL
+
+Atelier 是一个基于 Roslyn 编译器平台、深度嵌入 Unifier 运行时的交互式 C# 工作台。它远不止"执行一段脚本"——它提供了持久会话与增量编译、实时诊断、代码补全、签名提示、语义高亮、虚拟括号配对、控制台输出重定向、后台任务追踪，以及基于 Surface 的窗口化交互界面。
+
+<details>
+<summary><strong>展开 Atelier REPL 实现细节深挖</strong></summary>
+
+#### 会话模型
+
+`ReplSession`（`src/Plugins/Atelier/Session`）维护一个随每次提交增量增长的 Roslyn `ScriptState`。支持两种执行模式：
+
+- **持久提交**：在当前 state 基础上编译并更新会话状态。变量、导入和定义在提交之间持续存在。
+- **瞬态运行**：在当前 state 基础上执行，但丢弃结果。适合一次性查询或验证，不污染会话状态。
+
+会话可以面向启动器上下文或某个正在运行的特定服务器。目标决定了哪些全局对象在作用域内——每个会话都会得到 `Launcher`、`Log`、`HostLabel`、`TargetLabel`、`Cancellation`、`PendingTasks` 和 `LastTask`；如果目标是服务器，还会额外得到 `Server`，它是对目标 `ServerContext` 的包装，并提供 dispatcher、peer 和 snapshot 等辅助访问。
+
+#### Roslyn Workspace 集成
+
+REPL 在执行状态旁边维护一个 Roslyn workspace（`src/Plugins/Atelier/Session/Roslyn`）。Workspace 追踪当前文档并提供语言服务：
+
+- **诊断**：输入时实时显示错误/警告标记，在提交之前就能发现问题
+- **补全**：由 `.` 或手动请求触发的上下文感知候选列表
+- **签名帮助**：打开方法调用括号时显示重载列表
+- **语义高亮**：超越语法层面的类型感知着色
+
+初始化后会启动一次预热，预加载 Roslyn 的核心程序集，减少首次使用的延迟。
+
+#### Draft 与 Source 的分离
+
+REPL 维护两个文本缓冲区：
+
+- **Draft**：用户看到的内容，包含虚拟括号提示等视觉辅助元素
+- **Source**：用于编译和执行的实际源代码文本
+
+这种分离让 UI 可以提供丰富的视觉反馈，同时不破坏 Roslyn 实际编译的代码。
+
+#### Surface 窗口生命周期
+
+REPL 窗口使用 `ISurfaceSession` 和交互作用域（`src/Plugins/Atelier/Presentation/Window`）。关闭时，系统会依次终止作用域、解除事件订阅、解绑控制台、取消 pending reads、排空命令队列、取消处理、释放 surface session，最后释放 `ReplSession`。这个序列确保了资源的干净释放，不留悬挂引用。
+
+#### 插件程序集引用
+
+REPL 可以引用当前加载的插件程序集，让脚本直接访问插件的公开 API。当被引用的程序集发生变化（插件重载或卸载）时，会话被标记为失效。用户会看到说明原因的提示，可以针对更新后的程序集重新打开会话。
+
+#### 元命令系统
+
+元命令以 `:` 开头，用于控制 REPL 本身而不是执行 C# 代码：
+
+| 命令 | 效果 |
+|------|------|
+| `:help` | 显示可用元命令 |
+| `:reset` | 重置会话状态 |
+| `:clear` | 清空输出区域 |
+| `:imports` | 列出 baseline/effective imports 与引用路径 |
+| `:target` | 显示当前 target 与 invocation host |
+| `:paste [on|off]` | 为多行提交切换粘贴模式 |
+| `:transient <code>` | 执行但不提交瞬态代码 |
+
+后台工作通过 `PendingTasks` 和 `LastTask` 跟踪；当前实现没有单独的 `:jobs` 或 `:cancel` 元命令。
+
+</details>
+
+#### 最佳实践
+
+1. **查询时使用瞬态模式** — 不污染会话状态
+2. **选择正确的目标上下文** — 全局状态用启动器上下文，世界相关操作用服务器上下文
+3. **留意会话失效** — 插件重载会让你的会话变为过期状态
+4. **长时间操作使用后台任务** — REPL 在任务运行期间保持响应
+5. **优先用 `:reset` 而不是关闭重开** — 只需要干净状态时，这样更快
 
 - `ServerContext` 继承了 USP 的 `RootContext`，将 Unifier 服务插入上下文（自定义控制台、数据包接收器、记录元数据）。涉及泰拉瑞亚世界/游戏状态的所有内容都会经过此上下文。
 - 网络修补程序 (`UnifiedNetworkPatcher`) 对 `NetplaySystemContext` 函数做 detour，以共享缓冲区并协调跨服务器发送/接收路径。

--- a/docs/dev-plugin.md
+++ b/docs/dev-plugin.md
@@ -38,6 +38,14 @@ This guide explains how to build plugins for UnifierTSL, how to take advantage o
   - [8.2 Shipping Additional Modules](#82-shipping-additional-modules)
   - [8.3 Multi-Server Coordination](#83-multi-server-coordination)
   - [8.4 Testing Strategies](#84-testing-strategies)
+- [9. Command System V2](#9-command-system-v2)
+  - [9.1 Declaring a Controller](#91-declaring-a-controller)
+  - [9.2 Parameter Binding](#92-parameter-binding)
+  - [9.3 Flags](#93-flags)
+  - [9.4 Guards and Permissions](#94-guards-and-permissions)
+  - [9.5 TShock-Specific Bindings](#95-tshock-specific-bindings)
+  - [9.6 Installing and Uninstalling](#96-installing-and-uninstalling)
+- [10. Atelier REPL](#10-atelier-repl)
 
 ## Important Best Practices
 
@@ -608,3 +616,260 @@ log.Info("Teleporting player", metadata: stackalloc[]
 - Instantiate `ServerContext` in headless tests to validate migrations against USP without running the full launcher.
 - Use event providers to simulate player joins, packet flows, or coordinator switches in isolation.
 - Consider building an integration test harness under `tests/` once the xUnit project is created per the repository guidelines.
+
+## 9. Command System V2
+
+The command system v2 gives you a structured, declarative way to define commands. Instead of registering string callbacks, you annotate static controller classes and methods with attributes. The framework handles discovery, parameter binding, permission checks, help text generation, Prompt completion, and audit logging — all from the same declarations.
+
+### 9.1 Declaring a Controller
+
+Controllers must be `static` classes. Actions must be static methods. This is intentional: controllers are declaration containers, not service instances.
+
+```csharp
+[CommandController("greet")]
+[Aliases("g")]
+public static class GreetCommand
+{
+    [CommandAction("player")]
+    [TShockCommand("myplugin.greet")]
+    public static CommandOutcome Player(
+        [TSPlayerRef] TSPlayer target,
+        [RemainingText] string? message = null)
+    {
+        var text = message ?? $"Hello, {target.Name}!";
+        return CommandOutcome.Success(text);
+    }
+
+    [MismatchHandler]
+    public static CommandOutcome OnMismatch()
+        => CommandOutcome.Usage("greet player <name> [message]");
+}
+```
+
+A few things worth noting here. The controller only declares the root and its actions; grouping happens on a separate type via `[ControllerGroup(typeof(GreetCommand), ...)]`, which you install as a unit. `[TerminalCommand]` and `[TShockCommand]` expose actions to different endpoints — you can combine them, but only when the parameter list can be satisfied by every endpoint you expose. `[MismatchHandler]` fires when the root matches but the action path or parameters don't; it can only consume injected values, not user-bound parameters.
+
+Architecturally, TShock is not a parallel command stack that happens to coexist with Command System V2. It plugs into and extends the V2 infrastructure with TShock-specific endpoints, permissions, binders, prompt behaviors, and audit integration. That means plugin authors usually should not build a separate adapter layer from scratch for player commands. If you are targeting TShock-style command execution, start from the TShock-facing facilities and patterns that already exist.
+
+### 9.2 Parameter Binding
+
+Parameters are bound from several sources depending on their type and attributes:
+
+**Scalar types** bind directly from positional tokens — no attribute needed:
+
+```csharp
+[CommandAction("set")]
+public static CommandOutcome Set(CommandInvocationContext ctx, string key, int value) { ... }
+```
+
+**Remaining text** collects everything after the last bound token:
+
+```csharp
+[CommandAction("say")]
+public static CommandOutcome Say(
+    [FromAmbientContext] TSExecutionContext exec,
+    [RemainingText] string message) { ... }
+```
+
+**Remaining args** gives you the tokens as an array:
+
+```csharp
+[CommandAction("run")]
+public static CommandOutcome Run(CommandInvocationContext ctx, [RemainingArgs] string[] args) { ... }
+```
+
+**Injected context** values come from the ambient execution context. `CommandInvocationContext` and `CancellationToken` are implicit; other ambient values should be marked with `[FromAmbientContext]`:
+
+```csharp
+[CommandAction("info")]
+public static CommandOutcome Info(
+    CommandInvocationContext ctx,   // command metadata, raw input
+    [FromAmbientContext] ServerContext server,
+    [FromAmbientContext] TSExecutionContext exec,
+    CancellationToken ct)           // for long-running ops
+{ ... }
+```
+
+### 9.3 Flags
+
+`CommandFlagsAttribute<TEnum>` maps a flags enum to command-line tokens. Flags can appear anywhere in the command — they're extracted before positional binding.
+
+```csharp
+[Flags]
+public enum KickFlags
+{
+    None = 0,
+    [CommandFlag("-s")] Silent = 1,
+    [CommandFlag("-b")] Ban = 2,
+}
+
+[CommandAction("kick")]
+[TShockCommand("myplugin.kick")]
+public static CommandOutcome Kick(
+    [FromAmbientContext] TSExecutionContext exec,
+    [TSPlayerRef] TSPlayer target,
+    [CommandFlags<KickFlags>] KickFlags flags,
+    [RemainingText] string reason)
+{
+    var silent = flags.HasFlag(KickFlags.Silent);
+    // ...
+    return CommandOutcome.Success($"Kicked {target.Name}");
+}
+```
+
+### 9.4 Guards and Permissions
+
+Pre-bind guards run before parameter binding, and post-bind guards run after binding but before the action body. They're useful for context availability checks or early permission gates that don't depend on user input.
+
+```csharp
+[CommandAction("reload")]
+[TerminalCommand(AllowLauncherConsole = false)]
+[RequireRunningServer]
+public static CommandOutcome Reload([FromAmbientContext] ServerContext server) { ... }
+
+public sealed class RequireRunningServerAttribute : PreBindGuardAttribute
+{
+    public override CommandGuardResult Evaluate(CommandInvocationContext context)
+        => context.Server?.IsRunning == true
+            ? CommandGuardResult.Continue()
+            : CommandGuardResult.Fail(CommandOutcome.Error("No server is currently running."));
+}
+```
+
+For TShock endpoints, `[TShockCommand("permission.node")]` or `[TShockCommand(nameof(Permissions.somePermission))]` is usually sufficient — the dispatcher checks permissions before binding. Guards are for cases where the check depends on injected context rather than the player's permission set.
+
+### 9.5 TShock-Specific Bindings
+
+TShock registers implicit bindings for its domain types, so you can use them directly in signatures:
+
+```csharp
+[CommandAction("group add")]
+[TShockCommand("tshock.group.add")]
+public static CommandOutcome GroupAdd(
+    [FromAmbientContext] TSExecutionContext exec,
+    Group group,
+    TSPlayer target)
+{ ... }
+```
+
+Implicit bindings are registered for common TShock domain types such as `TSPlayer`, `Group`, `Warp`, `Region`, and `UserAccount`. Additional explicit binders include `[TSItemRef]`, `[NpcRef]`, `[ProjectileRef]`, `[TileRef]`, `[PageRef]`, `[CommandRef]`, and `[WorldTime]`. Greedy phrase matching is type-specific or opt-in — for example, `RegionRef` is greedy by default, while player/item bindings expose options to switch consumption mode when you need names with spaces.
+
+For most gameplay/admin plugins, this is the default integration path you want. TShock already bridges Command System V2 into player-facing command execution, permissions, REST exposure, prompt/completion behavior, and outcome formatting. Unless you have a genuinely different surface or policy model, prefer building on the TShock facilities the same way `src/Plugins/CommandTeleport` does instead of designing your own command-access layer.
+
+Another way to think about the architecture is:
+
+- **UTSL V2 provides the neutral machinery**.
+- **TShock turns that machinery into a TShock-native command surface**.
+- **Your plugin should usually plug into that TShock-native surface, not rebuild it**.
+
+That separation is what keeps the lower layer generic while still giving plugin authors a high-level, batteries-included path for common admin/gameplay commands.
+
+### 9.6 Installing and Uninstalling
+
+Group your controllers with `[ControllerGroup]` and install them in `InitializeAsync`:
+
+```csharp
+[ControllerGroup(typeof(GreetCommand), typeof(KickCommand))]
+public sealed partial class MyCommandGroup { }
+
+// In your plugin:
+IDisposable? _commandRegistration;
+
+public override Task InitializeAsync(
+    IPluginConfigRegistrar configRegistrar,
+    ImmutableArray<PluginInitInfo> priorInitializations,
+    CancellationToken cancellationToken = default)
+{
+    _commandRegistration = CommandSystem.Install(static context =>
+        context.AddControllerGroup<MyCommandGroup>());
+    return Task.CompletedTask;
+}
+
+public override ValueTask DisposeAsync(bool isDisposing)
+{
+    if (isDisposing) {
+        _commandRegistration?.Dispose();
+        _commandRegistration = null;
+    }
+
+    return base.DisposeAsync(isDisposing);
+}
+```
+
+`CommandSystem.Install` returns a `CommandInstallHandle` (or can be held as `IDisposable`). Disposing it removes exactly the commands your plugin contributed, leaving everything else intact.
+
+## 10. Atelier REPL
+
+Atelier is a Roslyn-based interactive C# workspace that runs inside the Unifier process. It's not a replacement for your IDE — it's a runtime workbench for exploration, diagnostics, and one-off automation. You can access live server state, call plugin APIs, and run arbitrary C# against the running system.
+
+### Opening a Session
+
+Use the `repl` terminal command from the launcher console or a per-server console. The command is terminal-only in the current build, and you can optionally override the default target:
+
+```
+repl                  # launcher console -> launcher target; server console -> current server target
+repl --server MyWorld # target a specific running server
+repl --launcher       # from a server console, switch the REPL target back to launcher scope
+```
+
+### Persistent vs. Transient Execution
+
+By default, submissions are **persistent** — variables and definitions accumulate across submissions:
+
+```csharp
+// Submission 1
+var serverNames = Launcher.RunningServers
+    .Select(s => s.Name)
+    .ToList();
+
+// Submission 2 — serverNames is still in scope
+serverNames.Count
+```
+
+Run `:transient <code>` to execute code **transiently** — the result is shown, but session state is unchanged. This is useful for one-off probes you don't want to commit to the running session.
+
+### Accessing Runtime State
+
+The REPL injects a `ScriptGlobals` host object. Every session gets `Launcher`, `Log`, `HostLabel`, `TargetLabel`, `Cancellation`, `PendingTasks`, and `LastTask`. Server-targeted sessions additionally expose `Server`, whose `Context` property is the underlying `ServerContext`.
+
+```csharp
+// List running servers
+Launcher.RunningServers.Select(s => s.Name)
+
+// Inspect the current server target
+Server?.Name
+Server?.Snapshot(TimeSpan.FromSeconds(10))
+```
+
+### Meta-Commands
+
+Meta-commands start with `:` and control the REPL itself:
+
+| Command | Effect |
+|---------|--------|
+| `:help` | List available meta-commands |
+| `:reset` | Clear session state (variables, imports) |
+| `:clear` | Clear the output display |
+| `:imports` | Show baseline/effective imports and reference paths |
+| `:target` | Show the current target and invocation host |
+| `:paste [on|off]` | Toggle paste mode for multi-line source entry |
+| `:transient <code>` | Run transient code without committing it |
+
+### Background Tasks
+
+Long-running operations can run in the background so the REPL stays responsive:
+
+```csharp
+// Start a background task
+var job = Task.Run(async () => {
+    await Task.Delay(5000, Cancellation);
+    return "done";
+}, Cancellation);
+```
+
+Background tasks are surfaced through `PendingTasks` and `LastTask`, and long-running code should honor `Cancellation`. The current build does not expose separate `:jobs` or `:cancel` meta-commands.
+
+### Tips
+
+- **Use transient mode for queries** — `:transient <code>` doesn't pollute session state
+- **Watch for session invalidation** — if a plugin you referenced reloads, your session is marked stale and you'll need to reopen it
+- **Promote to a command** — once a REPL snippet proves useful, consider turning it into a proper `CommandAction` so it's available to all operators

--- a/docs/dev-plugin.zh-cn.md
+++ b/docs/dev-plugin.zh-cn.md
@@ -38,6 +38,14 @@
   - [8.2 发布附加模块](#82-shipping-additional-modules)
   - [8.3 多服务器协调](#83-multi-server-coordination)
   - [8.4 测试策略](#84-testing-strategies)
+- [9. 命令系统 V2](#9-命令系统-v2)
+  - [9.1 声明控制器](#91-声明控制器)
+  - [9.2 参数绑定](#92-参数绑定)
+  - [9.3 Flags](#93-flags)
+  - [9.4 守卫与权限](#94-守卫与权限)
+  - [9.5 TShock 专属绑定](#95-tshock-专属绑定)
+  - [9.6 安装与卸载](#96-安装与卸载)
+- [10. Atelier REPL](#10-atelier-repl)
 
 <a id="important-best-practices"></a>
 ## 重要实践建议
@@ -642,4 +650,266 @@ log.Info("Teleporting player", metadata: stackalloc[]
 - 使用事件提供程序来模拟玩家加入、数据包流或隔离的协调器切换。
 - 一旦根据存储库指南创建了 xUnit 项目，请考虑在 `tests/` 下构建集成测试工具。
 
+<a id="9-命令系统-v2"></a>
+## 9. 命令系统 V2
 
+命令系统 v2 提供了一种结构化、声明式的命令定义方式。你不再需要注册字符串回调，而是通过属性标注静态控制器类和方法来描述命令的结构。框架负责发现、参数绑定、权限检查、帮助文本生成、Prompt 补全以及审计日志——这一切都来自同一套声明。
+
+<a id="91-声明控制器"></a>
+### 9.1 声明控制器
+
+控制器必须是 `static` 类，动作必须是静态方法。这是有意为之的设计：控制器是声明容器，而不是服务实例。
+
+```csharp
+[CommandController("greet")]
+[Aliases("g")]
+public static class GreetCommand
+{
+    [CommandAction("player")]
+    [TShockCommand("myplugin.greet")]
+    public static CommandOutcome Player(
+        [TSPlayerRef] TSPlayer target,
+        [RemainingText] string? message = null)
+    {
+        var text = message ?? $"Hello, {target.Name}!";
+        return CommandOutcome.Success(text);
+    }
+
+    [MismatchHandler]
+    public static CommandOutcome OnMismatch()
+        => CommandOutcome.Usage("greet player <玩家名> [消息]");
+}
+```
+
+这里有几点值得注意。控制器本身只声明根命令和动作；分组是在单独的类型上通过 `[ControllerGroup(typeof(GreetCommand), ...)]` 完成的，然后再把这个组作为一个单元安装。`[TerminalCommand]` 和 `[TShockCommand]` 可以把动作暴露到不同端点，但只有当参数列表能被所有目标端点满足时才应该组合使用。`[MismatchHandler]` 在根命令匹配但动作路径或参数不匹配时触发；它只能消费注入值，不能声明用户绑定的参数。
+
+从架构上说，TShock 不是一套与 Command System V2 平行存在、彼此独立的命令栈。它是在 V2 通用设施之上完成接入和扩展，补上了 TShock 专属的端点、权限、绑定器、Prompt 行为和审计集成。因此插件作者通常不应该再自己从头搭一层玩家命令接入。如果你的目标就是 TShock 风格的命令执行，优先直接使用仓库里已经接好的 TShock 设施和模式。
+
+<a id="92-参数绑定"></a>
+### 9.2 参数绑定
+
+参数根据类型和属性从不同来源绑定：
+
+**标量类型**直接从位置 token 绑定，无需属性：
+
+```csharp
+[CommandAction("set")]
+public static CommandOutcome Set(CommandInvocationContext ctx, string key, int value) { ... }
+```
+
+**剩余文本**收集最后一个绑定 token 之后的所有内容：
+
+```csharp
+[CommandAction("say")]
+public static CommandOutcome Say(
+    [FromAmbientContext] TSExecutionContext exec,
+    [RemainingText] string message) { ... }
+```
+
+**剩余参数**以数组形式提供 token：
+
+```csharp
+[CommandAction("run")]
+public static CommandOutcome Run(CommandInvocationContext ctx, [RemainingArgs] string[] args) { ... }
+```
+
+**注入的上下文**值来自 ambient execution context。`CommandInvocationContext` 和 `CancellationToken` 会被隐式识别；其他 ambient 值应通过 `[FromAmbientContext]` 显式标注：
+
+```csharp
+[CommandAction("info")]
+public static CommandOutcome Info(
+    CommandInvocationContext ctx,   // 命令元数据、原始输入
+    [FromAmbientContext] ServerContext server,
+    [FromAmbientContext] TSExecutionContext exec,
+    CancellationToken ct)           // 用于长时间运行的操作
+{ ... }
+```
+
+<a id="93-flags"></a>
+### 9.3 Flags
+
+`CommandFlagsAttribute<TEnum>` 将 flags enum 映射到命令行 token。Flags 可以出现在命令的任意位置——它们在位置参数绑定之前就被提取出来。
+
+```csharp
+[Flags]
+public enum KickFlags
+{
+    None = 0,
+    [CommandFlag("-s")] Silent = 1,
+    [CommandFlag("-b")] Ban = 2,
+}
+
+[CommandAction("kick")]
+[TShockCommand("myplugin.kick")]
+public static CommandOutcome Kick(
+    [FromAmbientContext] TSExecutionContext exec,
+    [TSPlayerRef] TSPlayer target,
+    [CommandFlags<KickFlags>] KickFlags flags,
+    [RemainingText] string reason)
+{
+    var silent = flags.HasFlag(KickFlags.Silent);
+    // ...
+    return CommandOutcome.Success($"已踢出 {target.Name}");
+}
+```
+
+<a id="94-守卫与权限"></a>
+### 9.4 守卫与权限
+
+前置守卫会在参数绑定之前运行，后置守卫会在绑定完成但动作体执行之前运行。它们适合用于上下文可用性检查，或依赖注入上下文而不是用户输入的早期门控。
+
+```csharp
+[CommandAction("reload")]
+[TerminalCommand(AllowLauncherConsole = false)]
+[RequireRunningServer]
+public static CommandOutcome Reload([FromAmbientContext] ServerContext server) { ... }
+
+public sealed class RequireRunningServerAttribute : PreBindGuardAttribute
+{
+    public override CommandGuardResult Evaluate(CommandInvocationContext context)
+        => context.Server?.IsRunning == true
+            ? CommandGuardResult.Continue()
+            : CommandGuardResult.Fail(CommandOutcome.Error("当前没有正在运行的服务器。"));
+}
+```
+
+对于 TShock 端点，`[TShockCommand("permission.node")]` 或 `[TShockCommand(nameof(Permissions.somePermission))]` 通常已经足够——分发器会在绑定之前检查权限。守卫适用于检查依赖注入上下文而非玩家权限集的场景。
+
+<a id="95-tshock-专属绑定"></a>
+### 9.5 TShock 专属绑定
+
+TShock 为其领域类型注册了隐式绑定，因此可以直接在签名中使用：
+
+```csharp
+[CommandAction("group add")]
+[TShockCommand("tshock.group.add")]
+public static CommandOutcome GroupAdd(
+    [FromAmbientContext] TSExecutionContext exec,
+    Group group,
+    TSPlayer target)
+{ ... }
+```
+
+常用的 TShock 领域类型（如 `TSPlayer`、`Group`、`Warp`、`Region`、`UserAccount`）已经注册了隐式绑定。额外的显式绑定器包括 `[TSItemRef]`、`[NpcRef]`、`[ProjectileRef]`、`[TileRef]`、`[PageRef]`、`[CommandRef]` 和 `[WorldTime]`。是否支持贪婪短语匹配取决于具体类型或属性选项——例如 `RegionRef` 默认就是贪婪匹配，而玩家/物品绑定则可以通过属性配置切换消费模式。
+
+对于大多数游戏管理类插件，这就是默认应该走的接入路径。TShock 已经把 Command System V2 桥接到了玩家命令执行、权限检查、REST 暴露、补全/提示行为以及结果格式化这些能力上。除非你真的需要完全不同的一套表面或策略模型，否则更推荐像 `src/Plugins/CommandTeleport` 那样直接建立在 TShock 设施之上，而不是再自行设计一层命令接入。
+
+换一种更直观的说法就是：
+
+- **UTSL V2 提供中立的通用机械结构**。
+- **TShock 把这套机械结构接成 TShock 原生命令表面**。
+- **你的插件多数情况下应该直接接到这层 TShock 原生命令表面，而不是重搭一遍**。
+
+正是这种分层，让下层仍然保持通用，同时又能给插件作者提供一条“开箱即用”的高层路径来实现常见的管理/游戏命令。
+
+<a id="96-安装与卸载"></a>
+### 9.6 安装与卸载
+
+用 `[ControllerGroup]` 将控制器分组，然后在 `InitializeAsync` 中安装：
+
+```csharp
+[ControllerGroup(typeof(GreetCommand), typeof(KickCommand))]
+public sealed partial class MyCommandGroup { }
+
+// 在你的插件中：
+IDisposable? _commandRegistration;
+
+public override Task InitializeAsync(
+    IPluginConfigRegistrar configRegistrar,
+    ImmutableArray<PluginInitInfo> priorInitializations,
+    CancellationToken cancellationToken = default)
+{
+    _commandRegistration = CommandSystem.Install(static context =>
+        context.AddControllerGroup<MyCommandGroup>());
+    return Task.CompletedTask;
+}
+
+public override ValueTask DisposeAsync(bool isDisposing)
+{
+    if (isDisposing) {
+        _commandRegistration?.Dispose();
+        _commandRegistration = null;
+    }
+
+    return base.DisposeAsync(isDisposing);
+}
+```
+
+`CommandSystem.Install` 返回 `CommandInstallHandle`，也可以按 `IDisposable` 保存。对它调用 `Dispose()` 时，只会移除你的插件注册进去的那部分命令，其他命令不受影响。
+
+<a id="10-atelier-repl"></a>
+## 10. Atelier REPL
+
+Atelier 是一个运行在 Unifier 进程内部的 Roslyn 交互式 C# 工作台。它不是 IDE 的替代品，而是一个运行时探索、诊断和临时自动化的工作台。你可以访问实时的服务器状态、调用插件 API，并针对运行中的系统执行任意 C# 代码。
+
+### 打开会话
+
+从启动器控制台或某个服务器控制台使用终端命令 `repl`。当前实现只暴露终端入口，并且可以按需覆盖默认目标：
+
+```
+repl                  # 启动器控制台 -> 目标是 launcher；服务器控制台 -> 目标是当前服务器
+repl --server MyWorld # 指向一个正在运行的指定服务器
+repl --launcher       # 从服务器控制台切回 launcher 作用域
+```
+
+### 持久执行与瞬态执行
+
+默认情况下，提交是**持久的**——变量和定义在提交之间累积：
+
+```csharp
+// 第一次提交
+var serverNames = Launcher.RunningServers
+    .Select(s => s.Name)
+    .ToList();
+
+// 第二次提交——serverNames 仍然在作用域内
+serverNames.Count
+```
+
+使用 `:transient <code>` 可以进行**瞬态**执行——结果会显示，但不会写回会话状态。这很适合做一次性的探针查询，而不污染当前会话。
+
+### 访问运行时状态
+
+REPL 会注入一个 `ScriptGlobals` 主机对象。每个会话都会得到 `Launcher`、`Log`、`HostLabel`、`TargetLabel`、`Cancellation`、`PendingTasks` 和 `LastTask`。如果目标是服务器，还会额外得到 `Server`，其 `Context` 属性就是底层的 `ServerContext`。
+
+```csharp
+// 列出运行中的服务器
+Launcher.RunningServers.Select(s => s.Name)
+
+// 查看当前服务器目标
+Server?.Name
+Server?.Snapshot(TimeSpan.FromSeconds(10))
+```
+
+### 元命令
+
+元命令以 `:` 开头，用于控制 REPL 本身：
+
+| 命令 | 效果 |
+|------|------|
+| `:help` | 列出可用元命令 |
+| `:reset` | 清除会话状态（变量、导入） |
+| `:clear` | 清空输出显示 |
+| `:imports` | 显示 baseline/effective imports 与引用路径 |
+| `:target` | 显示当前 target 与 invocation host |
+| `:paste [on|off]` | 为多行源码输入切换粘贴模式 |
+| `:transient <code>` | 执行但不提交瞬态代码 |
+
+### 后台任务
+
+长时间运行的操作可以在后台执行，让 REPL 保持响应：
+
+```csharp
+var job = Task.Run(async () => {
+    await Task.Delay(5000, Cancellation);
+    return "完成";
+}, Cancellation);
+```
+
+后台任务会通过 `PendingTasks` 和 `LastTask` 暴露出来；长时间运行的代码也应该遵守 `Cancellation`。当前实现没有单独的 `:jobs` 或 `:cancel` 元命令。
+
+### 使用建议
+
+- **查询时使用瞬态模式** — `:transient <code>` 不污染会话状态
+- **留意会话失效** — 如果你引用的插件重载了，会话会被标记为过期，需要重新打开
+- **将有效的片段提炼为命令** — 一旦某个 REPL 片段被反复使用并证明有效，可以考虑将它固化为一个 `CommandAction`，让所有运维人员都能使用


### PR DESCRIPTION
## Summary by Sourcery

Document Command System V2 and the Atelier REPL across the developer docs and README, and bump the project version for the next release.

Build:
- Update GitVersion configuration to bump the next-version from v0.2.1 to v0.3.1.

Documentation:
- Add detailed plugin developer documentation for Command System V2, including controller declarations, parameter binding, flags, guards, TShock-specific bindings, and installation/uninstallation, in both English and Chinese guides.
- Introduce a new section describing Atelier REPL usage, session model, meta-commands, and best practices in the plugin dev guide in both English and Chinese.
- Explain Command System V2 and Atelier REPL as core subsystems in the developer overview docs, with deep-dive implementation details and architectural best practices, in both English and Chinese.
- Highlight Command System V2 and Atelier REPL as headline features in the main README and docs README, and reference where to find more detailed guides.