### PR TITLE
fix: remove player.active assignment to avoid unexpected tile section sending

### DIFF
--- a/src/UnifierTSL/UnifiedServerCoordinator.cs
+++ b/src/UnifierTSL/UnifiedServerCoordinator.cs
@@ -263,9 +263,7 @@ namespace UnifierTSL
                                     globalClients[Index].ResetSections(joinServer);
 
                                     SetClientCurrentlyServer(Index, joinServer);
-
-                                    serverPlayer.active = true;
-
+                                    
                                     UnifierApi.EventHub.Coordinator.JoinServer.Invoke(new(joinServer, player.whoAmI));
 
                                     UnifierApi.UpdateTitle();


### PR DESCRIPTION
### PE收到`TileSection`神秘闪退
1. 处理`ProcessPacket`方法 处理`UUID`包的时候把`Player.active`设为了`true`
2. `Main.UpdateServer`里的`CheckSection`（用来根据玩家坐标发送区块）提前给玩家发送了区块
3. 手机没收到`WorldInfo`所以没初始化`Tile`数组，收到`CheckSection`发送的区块直接崩了

解决方法是把`UUID`包处理的`serverPlayer.active = true`删了，走原版逻辑，玩家发`PlayerActive`包再把`active`设为`true`

## Summary by Sourcery

Bug Fixes:
- Avoid PE client crashes by no longer marking players active on UUID packet handling, relying on PlayerActive packets for activation instead.