### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ The baseline values below come straight from project files and restored package 
 | Component | Version | Source |
 |:--|:--|:--|
 | Target framework | `.NET 9.0` | `src/UnifierTSL/*.csproj` |
-| Terraria | `1.4.5.7` | `OTAPI.dll` from the OTAPI USP package referenced by this project |
-| OTAPI USP | `1.2.0-pre-release-upstream.2` | `src/UnifierTSL/UnifierTSL.csproj` |
+| Terraria | `1.4.5.8` | `OTAPI.dll` from the OTAPI USP package referenced by this project |
+| OTAPI USP | `1.2.0-pre-release-upstream.5` | `src/UnifierTSL/UnifierTSL.csproj` |
 
 <details>
 <summary><strong>TShock and dependency details</strong></summary>

--- a/docs/README.zh-cn.md
+++ b/docs/README.zh-cn.md
@@ -141,8 +141,8 @@ UnifierTSL 把 [OTAPI Unified Server Process](https://github.com/CedaryCat/OTAPI
 | 组件 | 版本 | 来源 |
 |:--|:--|:--|
 | 目标框架 | `.NET 9.0` | `src/UnifierTSL/*.csproj` |
-| Terraria | `1.4.5.7` | 项目引用的 OTAPI.USP 包中的 `OTAPI.dll` |
-| OTAPI USP | `1.2.0-pre-release-upstream.2` | `src/UnifierTSL/UnifierTSL.csproj` |
+| Terraria | `1.4.5.8` | 项目引用的 OTAPI.USP 包中的 `OTAPI.dll` |
+| OTAPI USP | `1.2.0-pre-release-upstream.5` | `src/UnifierTSL/UnifierTSL.csproj` |
 
 <details>
 <summary><strong>TShock 与依赖详情</strong></summary>

--- a/src/UnifierTSL/UnifiedServerCoordinator.cs
+++ b/src/UnifierTSL/UnifiedServerCoordinator.cs
@@ -544,8 +544,12 @@ namespace UnifierTSL
                         if (unreadLength >= packetLength && packetLength != 0) {
                             CountReceivedData(clientIndex, (uint)packetLength, server);
 
-                            // buffer.GetData(server, readPosition + 2, packetLength - 2, out var _);
-                            NetPacketHandler.ProcessBytes(server, buffer, readPosition + 2, packetLength - 2);
+                            try {
+                                NetPacketHandler.ProcessBytes(server, buffer, readPosition + 2, packetLength - 2);
+                            }
+                            catch (Exception exception) {
+                                netMsg.LogMessageError(clientIndex, buffer.readBuffer[readPosition + 2].ToString(), exception);
+                            }
 
                             if (server.Main.dedServ && server.Netplay.Clients[clientIndex].PendingTermination) {
                                 server.Netplay.Clients[clientIndex].PendingTerminationApproved = true;
@@ -574,14 +578,9 @@ namespace UnifierTSL
                     }
                 }
                 catch (Exception exception) {
-                    if (server.Main.dedServ && readPosition < globalMsgBuffers.Length - 100) {
-                        server.Log.Error(
-                            Language.GetTextValue("Error.NetMessageError", globalMsgBuffers[readPosition + 2]),
-                            exception);
-                    }
+                    netMsg.LogMessageError(clientIndex, "?", exception);
                     unreadLength = 0;
                     readPosition = 0;
-                    server.Hooks.NetMessage.InvokeCheckBytesException(exception);
                 }
                 if (unreadLength != buffer.totalData) {
                     for (int i = 0; i < unreadLength; i++) {

--- a/src/UnifierTSL/UnifierTSL.csproj
+++ b/src/UnifierTSL/UnifierTSL.csproj
@@ -37,7 +37,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="OTAPI.USP" Version="1.2.0-pre-release-upstream.2" />
+		<PackageReference Include="OTAPI.USP" Version="1.2.0-pre-release-upstream.5" />
 		<PackageReference Include="ModFramework" Version="1.1.15" />
 		<PackageReference Include="MonoMod.RuntimeDetour" Version="25.2.3" />
 		<PackageReference Include="MonoMod.RuntimeDetour.HookGen" Version="22.7.31.1" />


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the Terraria server dependencies and make network message processing more resilient to packet errors.

Bug Fixes:
- Improve network packet error handling by isolating packet-processing failures and consistently logging malformed or failed messages without interrupting the receive loop.

Enhancements:
- Update the project to Terraria 1.4.5.8 and OTAPI USP 1.2.0-pre-release-upstream.5.

Documentation:
- Update the English and Chinese version references to match the upgraded Terraria and OTAPI USP dependencies.