### PR TITLE
fix: TShock command formatting

### DIFF
--- a/src/Plugins/TShockAPI/Commanding/V2/ManagementCommands.cs
+++ b/src/Plugins/TShockAPI/Commanding/V2/ManagementCommands.cs
@@ -430,7 +430,7 @@ namespace TShockAPI.Commanding.V2
 
         private static PaginationTools.Settings CreateHelpPageSettings() {
             return new PaginationTools.Settings {
-                HeaderFormat = GetString("Group Sub-Commands ({0}/{1}):"),
+                HeaderFormat = GetString("Group Sub-Commands ({{0}}/{{1}}):"),
                 FooterFormat = GetString("Type {0}group help {{0}} for more sub-commands.", Commands.Specifier),
             };
         }
@@ -441,7 +441,7 @@ namespace TShockAPI.Commanding.V2
 
         private static PaginationTools.Settings CreateGroupListPageSettings() {
             return new PaginationTools.Settings {
-                HeaderFormat = GetString("Groups ({0}/{1}):"),
+                HeaderFormat = GetString("Groups ({{0}}/{{1}}):"),
                 FooterFormat = GetString("Type {0}group list {{0}} for more.", Commands.Specifier),
             };
         }

--- a/src/Plugins/TShockAPI/Commanding/V2/PlayerManagementCommands.cs
+++ b/src/Plugins/TShockAPI/Commanding/V2/PlayerManagementCommands.cs
@@ -857,7 +857,7 @@ namespace TShockAPI.Commanding.V2
 
         private static PaginationTools.Settings CreateIdentifierHelpPageSettings() {
             return new PaginationTools.Settings {
-                HeaderFormat = GetString("Available identifiers ({0}/{1}):"),
+                HeaderFormat = GetString("Available identifiers ({{0}}/{{1}}):"),
                 FooterFormat = GetString("Type {0}ban help identifiers {{0}} for more.", Commands.Specifier),
                 NothingToDisplayString = GetString("There are currently no available identifiers."),
                 HeaderTextColor = Color.White,

--- a/src/Plugins/TShockAPI/Commanding/V2/PlayerManagementCommands.cs
+++ b/src/Plugins/TShockAPI/Commanding/V2/PlayerManagementCommands.cs
@@ -845,7 +845,7 @@ namespace TShockAPI.Commanding.V2
 
         private static PaginationTools.Settings CreateBanListPageSettings() {
             return new PaginationTools.Settings {
-                HeaderFormat = GetString("Bans ({0}/{1}):"),
+                HeaderFormat = GetString("Bans ({{0}}/{{1}}):"),
                 FooterFormat = GetString("Type {0}ban list {{0}} for more.", Commands.Specifier),
                 NothingToDisplayString = GetString("There are currently no active bans."),
             };

--- a/src/Plugins/TShockAPI/Commanding/V2/RegionCommands.cs
+++ b/src/Plugins/TShockAPI/Commanding/V2/RegionCommands.cs
@@ -622,7 +622,7 @@ namespace TShockAPI.Commanding.V2
 
         private static PaginationTools.Settings CreateRegionListPageSettings() {
             return new PaginationTools.Settings {
-                HeaderFormat = GetString("Regions ({0}/{1}):"),
+                HeaderFormat = GetString("Regions ({{0}}/{{1})}:"),
                 FooterFormat = GetString("Type {0}region list {{0}} for more.", Commands.Specifier),
                 NothingToDisplayString = GetString("There are currently no regions defined."),
             };

--- a/src/Plugins/TShockAPI/Commanding/V2/TeleportCommands.cs
+++ b/src/Plugins/TShockAPI/Commanding/V2/TeleportCommands.cs
@@ -488,7 +488,7 @@ namespace TShockAPI.Commanding.V2
 
         private static PaginationTools.Settings CreateWarpListPageSettings() {
             return new PaginationTools.Settings {
-                HeaderFormat = GetString("Warps ({0}/{1}):"),
+                HeaderFormat = GetString("Warps ({{0}}/{{1}}):"),
                 FooterFormat = GetString("Type {0}warp list {{0}} for more.", Commands.Specifier),
                 NothingToDisplayString = GetString("There are currently no warps defined.")
             };

--- a/src/Plugins/TShockAPI/Commanding/V2/WorldUtilityCommands.cs
+++ b/src/Plugins/TShockAPI/Commanding/V2/WorldUtilityCommands.cs
@@ -172,7 +172,7 @@ namespace TShockAPI.Commanding.V2
 
         public static PaginationTools.Settings CreateGrowHelpPageSettings() {
             return new PaginationTools.Settings {
-                HeaderFormat = GetString("Trees types & misc available to use. ({0}/{1}):"),
+                HeaderFormat = GetString("Trees types & misc available to use. ({{0}}/{{1}}):"),
                 FooterFormat = GetString("Type {0}grow help {{0}} for more sub-commands.", Commands.Specifier),
             };
         }


### PR DESCRIPTION
A very small fix for TShock command formatting. Before this fix, some commands would throw a formatting error instead of displaying their output. This change fixes the formatting issue and restores the expected command output.
Before:
<img width="959" height="506" alt="Screenshot From 2026-09-07 20-52-51" src="https://github.com/user-attachments/assets/4634244a-989b-4b62-9059-6dda3406ab95" />

## Summary by Sourcery

Bug Fixes:
- Fix pagination header formatting for group, ban, identifier, region, warp, and grow commands so command output displays correctly instead of raising formatting errors.